### PR TITLE
Corrected some confusion in the examples

### DIFF
--- a/examples/framerate.py
+++ b/examples/framerate.py
@@ -35,7 +35,7 @@ print("""
 framerate.py - Test LCD framerate.
 
 If you're using Breakout Garden, plug the 1.3" LCD (SPI)
-breakout into the rear slot.
+breakout into the front slot.
 
 Running at: {}MHz
 """.format(SPI_SPEED_MHZ))
@@ -43,7 +43,7 @@ Running at: {}MHz
 # Create ST7789 LCD display class.
 disp = ST7789.ST7789(
     port=0,
-    cs=ST7789.BG_SPI_CS_FRONT,  # BG_SPI_CSB_BACK or BG_SPI_CS_FRONT
+    cs=ST7789.BG_SPI_CS_FRONT,  # BG_SPI_CS_BACK or BG_SPI_CS_FRONT
     dc=9,
     backlight=19,               # 18 for back BG slot, 19 for front BG slot.
     rotation=90,

--- a/examples/gif.py
+++ b/examples/gif.py
@@ -39,7 +39,7 @@ else:
 # Create TFT LCD display class.
 disp = ST7789.ST7789(
     port=0,
-    cs=ST7789.BG_SPI_CS_FRONT,  # BG_SPI_CSB_BACK or BG_SPI_CS_FRONT
+    cs=ST7789.BG_SPI_CS_FRONT,  # BG_SPI_CS_BACK or BG_SPI_CS_FRONT
     dc=9,
     backlight=19,               # 18 for back BG slot, 19 for front BG slot.
     spi_speed_hz=80 * 1000 * 1000

--- a/examples/image.py
+++ b/examples/image.py
@@ -27,7 +27,7 @@ print("""
 image.py - Display an image on the LCD.
 
 If you're using Breakout Garden, plug the 1.3" LCD (SPI)
-breakout into the rear slot.
+breakout into the front slot.
 """)
 
 if len(sys.argv) < 2:
@@ -39,7 +39,7 @@ image_file = sys.argv[1]
 # Create ST7789 LCD display class.
 disp = ST7789.ST7789(
     port=0,
-    cs=ST7789.BG_SPI_CS_FRONT,  # BG_SPI_CSB_BACK or BG_SPI_CS_FRONT
+    cs=ST7789.BG_SPI_CS_FRONT,  # BG_SPI_CS_BACK or BG_SPI_CS_FRONT
     dc=9,
     backlight=19,               # 18 for back BG slot, 19 for front BG slot.
     spi_speed_hz=80 * 1000 * 1000

--- a/examples/scrolling-text.py
+++ b/examples/scrolling-text.py
@@ -11,7 +11,7 @@ MESSAGE = "Hello World! How are you today?"
 # Create ST7789 LCD display class.
 disp = ST7789.ST7789(
     port=0,
-    cs=ST7789.BG_SPI_CS_FRONT,  # BG_SPI_CSB_BACK or BG_SPI_CS_FRONT
+    cs=ST7789.BG_SPI_CS_FRONT,  # BG_SPI_CS_BACK or BG_SPI_CS_FRONT
     dc=9,
     backlight=19,               # 18 for back BG slot, 19 for front BG slot.
     spi_speed_hz=80 * 1000 * 1000

--- a/examples/shapes.py
+++ b/examples/shapes.py
@@ -28,14 +28,14 @@ print("""
 shapes.py - Display test shapes on the LCD using PIL.
 
 If you're using Breakout Garden, plug the 1.3" LCD (SPI)
-breakout into the rear slot.
+breakout into the front slot.
 
 """)
 
 # Create ST7789 LCD display class.
 disp = ST7789.ST7789(
     port=0,
-    cs=ST7789.BG_SPI_CS_FRONT,  # BG_SPI_CSB_BACK or BG_SPI_CS_FRONT
+    cs=ST7789.BG_SPI_CS_FRONT,  # BG_SPI_CS_BACK or BG_SPI_CS_FRONT
     dc=9,
     backlight=19,               # 18 for back BG slot, 19 for front BG slot.
     rotation=90,


### PR DESCRIPTION
The examples (mostly) output a message telling you to use the *rear* slot in the breakout garden, while the code accesses the *front* slot.

The comment where the slot is selected also has a typo, referring to BG_SPI_CSB_BACK, when it should be BG_SPI_CS_BACK.

Just a couple of things that tripped me up when trying to use the breakout; hopefully this will save others the same confusion!