### PR TITLE
add support to display opencv images

### DIFF
--- a/library/ST7789/__init__.py
+++ b/library/ST7789/__init__.py
@@ -341,7 +341,11 @@ class ST7789(object):
         """Generator function to convert a PIL image to 16-bit 565 RGB bytes."""
         # NumPy is much faster at doing this. NumPy code provided by:
         # Keith (https://www.blogger.com/profile/02555547344016007163)
-        pb = np.rot90(np.array(image.convert('RGB')), rotation // 90).astype('uint8')
+        if type(image) == np.ndarray:
+            pb = np.rot90(image, rotation // 90).astype('uint8')
+        else:
+            pb = np.rot90(np.array(image.convert('RGB')), rotation // 90).astype('uint8')
+
 
         result = np.zeros((self._width, self._height, 2), dtype=np.uint8)
         result[..., [0]] = np.add(np.bitwise_and(pb[..., [0]], 0xF8), np.right_shift(pb[..., [1]], 5))


### PR DESCRIPTION
This is a small change to display opencv images, as they are already numpy arrays.
This  makes it easy to play video files or camera capture.
Make sure to call `image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)` before you pass the image to `display()`.