### PR TITLE
Feature/240x135 lcd

### DIFF
--- a/examples/framerate.py
+++ b/examples/framerate.py
@@ -31,19 +31,22 @@ Usage: {} <spi_speed_mhz> <display_type>
 Where <display_type> is one of:
   * square - 240x240 1.3" Square LCD
   * round  - 240x240 1.3" Round LCD (applies an offset)
+  * rect   - 240x135 1.14" Rectangular LCD (applies an offset)
 
 Running at: {}MHz on a {} display.
 """.format(sys.argv[0], SPI_SPEED_MHZ, display_type))
 
 # Create ST7789 LCD display class.
 disp = ST7789.ST7789(
+    height=135 if display_type == "rect" else 240,
+    rotation=0 if display_type == "rect" else 90,
     port=0,
     cs=ST7789.BG_SPI_CS_FRONT,  # BG_SPI_CS_BACK or BG_SPI_CS_FRONT
     dc=9,
     backlight=19,               # 18 for back BG slot, 19 for front BG slot.
-    rotation=90,
     spi_speed_hz=SPI_SPEED_MHZ * 1000000,
-    offset_left=40 if display_type == "round" else 0
+    offset_left=0 if display_type == "square" else 40,
+    offset_top=53 if display_type == "rect" else 0
 )
 
 WIDTH = disp.width
@@ -56,9 +59,9 @@ for step in range(STEPS):
     draw = ImageDraw.Draw(image)
 
     if step % 2 == 0:
-        draw.rectangle((120, 120, 240, 240), (0, 128, 0))
+        draw.rectangle((WIDTH/2, int(HEIGHT/2), WIDTH, HEIGHT), (0, 128, 0))
     else:
-        draw.rectangle((0, 0, 119, 119), (0, 128, 0))
+        draw.rectangle((0, 0, WIDTH/2-1, int(HEIGHT/2)-1), (0, 128, 0))
 
     f = math.sin((float(step) / STEPS) * math.pi)
     offset_left = int(f * WIDTH)

--- a/examples/gif.py
+++ b/examples/gif.py
@@ -21,6 +21,7 @@ Where <gif_file> is a .gif file.
 And <display_type> is one of:
   * square - 240x240 1.3" Square LCD
   * round  - 240x240 1.3" Round LCD (applies an offset)
+  * rect   - 240x135 1.14" Rectangular LCD (applies an offset)
 """.format(path=sys.argv[0]))
     sys.exit(1)
 
@@ -33,12 +34,15 @@ except IndexError:
 
 # Create TFT LCD display class.
 disp = ST7789.ST7789(
+    height=135 if display_type == "rect" else 240,
+    rotation=0 if display_type == "rect" else 90,
     port=0,
     cs=ST7789.BG_SPI_CS_FRONT,  # BG_SPI_CS_BACK or BG_SPI_CS_FRONT
     dc=9,
     backlight=19,               # 18 for back BG slot, 19 for front BG slot.
     spi_speed_hz=80 * 1000 * 1000,
-    offset_left=40 if display_type == "round" else 0
+    offset_left=0 if display_type == "square" else 40,
+    offset_top=53 if display_type == "rect" else 0
 )
 
 # Initialize display.

--- a/examples/image.py
+++ b/examples/image.py
@@ -18,6 +18,7 @@ if len(sys.argv) < 2:
 Where <display_type> is one of:
   * square - 240x240 1.3" Square LCD
   * round  - 240x240 1.3" Round LCD (applies an offset)
+  * rect   - 240x135 1.14" Rectangular LCD (applies an offset)
 """.format(sys.argv[0]))
     sys.exit(1)
 
@@ -30,12 +31,15 @@ except IndexError:
 
 # Create ST7789 LCD display class.
 disp = ST7789.ST7789(
+    height=135 if display_type == "rect" else 240,
+    rotation=0 if display_type == "rect" else 90,
     port=0,
     cs=ST7789.BG_SPI_CS_FRONT,  # BG_SPI_CS_BACK or BG_SPI_CS_FRONT
     dc=9,
     backlight=19,               # 18 for back BG slot, 19 for front BG slot.
     spi_speed_hz=80 * 1000 * 1000,
-    offset_left=40 if display_type == "round" else 0
+    offset_left=0 if display_type == "square" else 40,
+    offset_top=53 if display_type == "rect" else 0
 )
 
 WIDTH = disp.width

--- a/examples/scrolling-text.py
+++ b/examples/scrolling-text.py
@@ -23,6 +23,7 @@ Where <display_type> is one of:
 
   * square - 240x240 1.3" Square LCD
   * round  - 240x240 1.3" Round LCD (applies an offset)
+  * rect   - 240x135 1.14" Rectangular LCD (applies an offset)
 """.format(sys.argv[0]))
 
 try:
@@ -38,12 +39,15 @@ except IndexError:
 
 # Create ST7789 LCD display class.
 disp = ST7789.ST7789(
+    height=135 if display_type == "rect" else 240,
+    rotation=0 if display_type == "rect" else 90,
     port=0,
     cs=ST7789.BG_SPI_CS_FRONT,  # BG_SPI_CS_BACK or BG_SPI_CS_FRONT
     dc=9,
     backlight=19,               # 18 for back BG slot, 19 for front BG slot.
     spi_speed_hz=80 * 1000 * 1000,
-    offset_left=40 if display_type == "round" else 0
+    offset_left=0 if display_type == "square" else 40,
+    offset_top=53 if display_type == "rect" else 0
 )
 
 # Initialize display.
@@ -62,7 +66,7 @@ font = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf"
 size_x, size_y = draw.textsize(MESSAGE, font)
 
 text_x = disp.width
-text_y = (240 - size_y) // 2
+text_y = (disp.height - size_y) // 2
 
 t_start = time.time()
 

--- a/examples/shapes.py
+++ b/examples/shapes.py
@@ -19,6 +19,7 @@ Where <display_type> is one of:
 
   * square - 240x240 1.3" Square LCD
   * round  - 240x240 1.3" Round LCD (applies an offset)
+  * rect   - 240x135 1.14" Rectangular LCD (applies an offset)
 """.format(sys.argv[0]))
 
 try:
@@ -28,13 +29,15 @@ except IndexError:
 
 # Create ST7789 LCD display class.
 disp = ST7789.ST7789(
+    height=135 if display_type == "rect" else 240,
+    rotation=0 if display_type == "rect" else 90,
     port=0,
     cs=ST7789.BG_SPI_CS_FRONT,  # BG_SPI_CS_BACK or BG_SPI_CS_FRONT
     dc=9,
     backlight=19,               # 18 for back BG slot, 19 for front BG slot.
-    rotation=90,
     spi_speed_hz=80 * 1000 * 1000,
-    offset_left=40 if display_type == "round" else 0
+    offset_left=0 if display_type == "square" else 40,
+    offset_top=53 if display_type == "rect" else 0
 )
 
 # Initialize display.

--- a/library/ST7789/__init__.py
+++ b/library/ST7789/__init__.py
@@ -346,7 +346,7 @@ class ST7789(object):
 
         pb = np.rot90(image, rotation // 90).astype('uint8')
 
-        result = np.zeros((self._width, self._height, 2), dtype=np.uint8)
+        result = np.zeros((self._height, self._width, 2), dtype=np.uint8)
         result[..., [0]] = np.add(np.bitwise_and(pb[..., [0]], 0xF8), np.right_shift(pb[..., [1]], 5))
         result[..., [1]] = np.add(np.bitwise_and(np.left_shift(pb[..., [1]], 3), 0xE0), np.right_shift(pb[..., [2]], 3))
         return result.flatten().tolist()

--- a/library/tests/test_dimensions.py
+++ b/library/tests/test_dimensions.py
@@ -3,3 +3,9 @@ def test_240_240(GPIO, spidev):
     display = ST7789.ST7789(port=0, cs=0, dc=24, width=240, height=240, rotation=0)
     assert display.width == 240
     assert display.height == 240
+
+def test_240_135(GPIO, spidev):
+    import ST7789
+    display = ST7789.ST7789(port=0, cs=0, dc=24, width=240, height=135, rotation=0)
+    assert display.width == 240
+    assert display.height == 135


### PR DESCRIPTION
Added support to the provided examples for 240x135 resolution LCD (successfully tested on Pimoroni Pico Display Pack).
One key change has been made to the library itself [here](https://github.com/pimoroni/st7789-python/compare/master...slabua:feature/240x135-lcd?expand=1#diff-899346a6ee09030bb9563c3a917c9bc2512f26905556f42ce0c781f26a63ecd9), that would otherwise fail for non square displays.